### PR TITLE
Fix for the case that the ocr option is a bool

### DIFF
--- a/bin/djvubind
+++ b/bin/djvubind
@@ -236,7 +236,8 @@ class Project:
 
         # Set cetain variables to the proper type
         self.opts['cores'] = int(self.opts['cores'])
-        self.opts['ocr'] = (self.opts['ocr'] == 'True')
+        if isinstance(self.opts['ocr'], str):
+            self.opts['ocr'] = (self.opts['ocr'] == 'True')
 
         # Overwrite or create values for certain command line options
         if opts.no_ocr:
@@ -458,5 +459,3 @@ if __name__ == '__main__':
 
     print('{0} Encoding all information to {1}.'.format(djvubind.utils.color('*', 'green'), proj.out))
     proj.bind()
-
-


### PR DESCRIPTION
I thought that pushing new commits would update the pull request #10. Doesn't look like it. So
I could not get OCR working until i made this change.
I think the problem is that i have no config file. Then `self.opts['ocr']` keep the bool type it got [earlier](https://github.com/strider1551/djvubind/blob/develop/bin/djvubind#L190), and as it was the bool `True` and not the string `'True'`, it got set to `False` with the old code.
The other way to deal with this would be to use a string in line 190, i guess.

(The two lines at the end got removed by emacs, which i have set to remove trailing whitespace automatically.)

This should sets it to `False` again when the setting is `'False'`.
