### PR TITLE
Convert the bit depth to int when identifying bitonal images.

### DIFF
--- a/djvubind/organizer.py
+++ b/djvubind/organizer.py
@@ -103,7 +103,8 @@ class Page:
         if utils.execute('identify -ping "{0}"'.format(self.path), capture=True).decode('utf8').find('1-bit') == -1:
             self.bitonal = False
         else:
-            if (utils.execute('identify -ping -format %z "{0}"'.format(self.path), capture=True).decode('utf8') != ('1' + os.linesep)):
+            if int(utils.execute('identify -ping -format %z "{0}"'.format(
+                    self.path), capture=True).decode('utf8')) != 1:
                 print("msg: {0}: Bitonal image but with a depth greater than 1.  Modifying image depth.".format(os.path.split(self.path)[1]))
                 utils.execute('mogrify -colorspace gray -depth 1 "{0}"'.format(self.path))
             self.bitonal = True


### PR DESCRIPTION
This should fix #8.
The problem was that you were looking for a newline and identify¹ does not print a newline when you use `-format`, unless you put a `\n` in the format string. This should work either way, but will blow up when identify does not return a number.

¹Version: ImageMagick 6.8.6-3 2014-04-08 Q16
